### PR TITLE
Funds distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Monzo pots
+
+A kotlin solution that uses the Monzo APIs to automate moving funds between pots.
+
+## Distribute funds
+
+It allows to take funds from a source pot and distribute them into other pots.
+
+The intention is to provide a salary sorter like functionality that can be triggered on demand. The source of the funds
+is not an incoming payment but a pot.
+
+### Why?
+
+I split my income into pots to have a better control of my budget. This is easy enough using the salary sorter, but I
+get paid in the middle of the month. I prefer to budget by calendar month, so it's much easier if the income is release
+on the first day of the month. The way I achieve that is by moving the full amount to a "buffer" pot that then I
+distribute on the last day of each month.
+
+### How it works?
+
+You provide a manifest indicating the following:
+
+- Source pot: the pot where the funds come from.
+- Deposit pots: the pots where the funds are distributed to.
+- Keep in main account: amount that should be withdrawn from the source pot, but it's not expected to move to other pot.
+  This is for certain expenses that are paid directly from the main account.
+- Remainder pot: special pot where you define a minimum amount that it should receive, and where the remainder funds get
+  moved to. This is to cater for months when the income varies, so that the deposit pots don't need to match the source.
+  This feature is intended for savings, where you set a minimum you want to save each month, but if you have more funds
+  available, then you can save more.
+
+The manifest in code looks like:
+
+```kotlin
+DistributionManifest(
+    mainAccount = AccountAddress("123456", "123456789"),
+    source = PotName("source"),
+    deposits = listOf(Deposit(to = PotName("destination"), amount = 10.pounds)),
+    keepInMainAccount = 10.pounds,
+    remainder = Remainder(to = PotName("Savings"), atLeast = 10.pounds)
+)
+```
+
+It currently can only be executed via console grabbing an auth token from the Monzo developer portal.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "1.8.0"
+    kotlin("plugin.serialization") version "1.8.0"
     application
 }
 
@@ -10,7 +11,11 @@ repositories {
 }
 
 dependencies {
+    implementation(libs.http4k.core)
+    implementation(libs.http4k.serialisation.kotlinx)
+    implementation(libs.kotlinx.datetime)
     testImplementation(kotlin("test"))
+    testImplementation(libs.junit.params)
 }
 
 tasks.test {
@@ -22,5 +27,5 @@ kotlin {
 }
 
 application {
-    mainClass.set("MainKt")
+    mainClass.set("lmirabal.MainKt")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,8 @@
+[versions]
+http4k = "4.36.0.0"
+
+[libraries]
+http4k-core = { module = "org.http4k:http4k-core", version.ref = "http4k" }
+http4k-serialisation-kotlinx = { module = "org.http4k:http4k-format-kotlinx-serialization", version.ref = "http4k" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.0" }
+junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.8.1" }

--- a/src/main/kotlin/Bank.kt
+++ b/src/main/kotlin/Bank.kt
@@ -1,0 +1,13 @@
+package lmirabal
+
+import lmirabal.finance.Amount
+import lmirabal.model.Account
+import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
+
+interface Bank {
+    fun getAccountBy(address: AccountAddress): Account
+    fun getPotsFor(account: Account): List<Pot>
+    fun deposit(from: Account, to: Pot, amount: Amount): Pot
+    fun withdraw(from: Pot, to: Account, amount: Amount): Pot
+}

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,7 +1,23 @@
-fun main(args: Array<String>) {
-    println("Hello World!")
+package lmirabal
 
-    // Try adding program arguments via Run/Debug configuration.
-    // Learn more about running applications: https://www.jetbrains.com/help/idea/running-applications.html.
-    println("Program arguments: ${args.joinToString()}")
+import lmirabal.finance.pound
+import lmirabal.infrastructure.MonzoApi
+import lmirabal.model.Account
+import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
+
+fun main(args: Array<String>) {
+    val monzo = MonzoApi(accessToken = args[0])
+    val currentAccount: Account = monzo.getAccountBy(AccountAddress(args[1], args[2]))
+    println(currentAccount)
+
+    val pots: List<Pot> = monzo.getPotsFor(currentAccount)
+    println(pots)
+
+    val pot = pots[0]
+    val afterDeposit = monzo.deposit(currentAccount, pot, 1.pound)
+    println(afterDeposit)
+
+    val afterWithdrawal = monzo.withdraw(pot, currentAccount, 1.pound)
+    println(afterWithdrawal)
 }

--- a/src/main/kotlin/StubBank.kt
+++ b/src/main/kotlin/StubBank.kt
@@ -7,7 +7,7 @@ import lmirabal.model.Pot
 import java.util.*
 
 data class CreateAccountRequest(val address: AccountAddress, val balance: Amount)
-data class CreatePotRequest(val account: Account, val name: String, val balance: Amount)
+data class CreatePotRequest(val account: Account, val name: PotName, val balance: Amount)
 
 class StubBank(private val idGenerator: IdGenerator = randomUuid()) : Bank {
     private val accounts = mutableMapOf<AccountAddress, Account>()
@@ -18,7 +18,7 @@ class StubBank(private val idGenerator: IdGenerator = randomUuid()) : Bank {
             .also { account -> accounts[request.address] = account }
 
     fun createPot(request: CreatePotRequest): Pot {
-        return Pot(idGenerator(), request.name, request.balance)
+        return Pot(idGenerator(), request.name.value, request.balance)
             .also { pot ->
                 pots.merge(request.account, setOf(pot)) { existing, newPot -> existing + newPot }
             }

--- a/src/main/kotlin/StubBank.kt
+++ b/src/main/kotlin/StubBank.kt
@@ -4,6 +4,7 @@ import lmirabal.finance.Amount
 import lmirabal.model.Account
 import lmirabal.model.AccountAddress
 import lmirabal.model.Pot
+import lmirabal.model.PotName
 import java.util.*
 
 data class CreateAccountRequest(val address: AccountAddress, val balance: Amount)
@@ -18,7 +19,7 @@ class StubBank(private val idGenerator: IdGenerator = randomUuid()) : Bank {
             .also { account -> accounts[request.address] = account }
 
     fun createPot(request: CreatePotRequest): Pot {
-        return Pot(idGenerator(), request.name.value, request.balance)
+        return Pot(idGenerator(), request.name, request.balance)
             .also { pot ->
                 pots.merge(request.account, setOf(pot)) { existing, newPot -> existing + newPot }
             }

--- a/src/main/kotlin/StubBank.kt
+++ b/src/main/kotlin/StubBank.kt
@@ -1,0 +1,66 @@
+package lmirabal
+
+import lmirabal.finance.Amount
+import lmirabal.model.Account
+import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
+import java.util.*
+
+data class CreateAccountRequest(val address: AccountAddress, val balance: Amount)
+data class CreatePotRequest(val account: Account, val name: String, val balance: Amount)
+
+class StubBank(private val idGenerator: IdGenerator = randomUuid()) : Bank {
+    private val accounts = mutableMapOf<AccountAddress, Account>()
+    private val pots = mutableMapOf<Account, Set<Pot>>()
+
+    fun createAccount(request: CreateAccountRequest): Account =
+        Account(id = idGenerator(), request.address, request.balance)
+            .also { account -> accounts[request.address] = account }
+
+    fun createPot(request: CreatePotRequest): Pot {
+        return Pot(idGenerator(), request.name, request.balance)
+            .also { pot ->
+                pots.merge(request.account, setOf(pot)) { existing, newPot -> existing + newPot }
+            }
+    }
+
+    override fun getAccountBy(address: AccountAddress): Account = accounts.getValue(address)
+
+    override fun getPotsFor(account: Account): List<Pot> = pots.getValue(account).toList()
+
+    override fun deposit(from: Account, to: Pot, amount: Amount): Pot {
+        val account: Account = accounts.getValue(from.address)
+        accounts[from.address] = account.withdraw(amount)
+        val allPots = pots.getValue(from)
+        val pot = allPots.first { it == to }
+        val updatedPot = pot.deposit(amount)
+        pots[from] = allPots - pot + updatedPot
+        return updatedPot
+    }
+
+    override fun withdraw(from: Pot, to: Account, amount: Amount): Pot {
+        val account: Account = accounts.getValue(to.address)
+        accounts[to.address] = account.deposit(amount)
+        val allPots = pots.getValue(to)
+        val pot = allPots.first { it == from }
+        val updatedPot = pot.withdraw(amount)
+        pots[to] = allPots - pot + updatedPot
+        return updatedPot
+    }
+}
+
+fun Account.deposit(amount: Amount): Account = Account(id, address, balance + amount)
+fun Account.withdraw(amount: Amount): Account {
+    if (balance < amount) throw IllegalArgumentException("Not enough funds! balance=$balance withdrawal=$amount")
+    return Account(id, address, balance - amount)
+}
+
+fun Pot.deposit(amount: Amount): Pot = Pot(id, name, balance + amount)
+fun Pot.withdraw(amount: Amount): Pot {
+    if (balance < amount) throw IllegalArgumentException("Not enough funds! balance=$balance withdrawal=$amount")
+    return Pot(id, name, balance - amount)
+}
+
+typealias IdGenerator = () -> String
+
+private fun randomUuid(): IdGenerator = { UUID.randomUUID().toString() }

--- a/src/main/kotlin/finance/Amount.kt
+++ b/src/main/kotlin/finance/Amount.kt
@@ -42,7 +42,7 @@ class Amount(val pence: Long) {
 
 
     companion object {
-
+        val ZERO = Amount(0)
         val ONE = Amount(100)
         fun ofPounds(pounds: Int) = ofPounds(pounds.toLong())
         fun ofPounds(pounds: Long) = Amount(pounds * 100)

--- a/src/main/kotlin/finance/Amount.kt
+++ b/src/main/kotlin/finance/Amount.kt
@@ -1,0 +1,54 @@
+package lmirabal.finance
+
+import kotlin.math.absoluteValue
+
+val Int.pounds: Amount
+    get() = Amount.ofPounds(this)
+
+val Int.pound: Amount
+    get() {
+        require(this == 1)
+        return Amount.ONE
+    }
+
+class Amount(val pence: Long) {
+
+    operator fun plus(that: Amount) = Amount(this.pence + that.pence)
+    operator fun minus(that: Amount) = Amount(this.pence - that.pence)
+    operator fun unaryMinus() = Amount(-pence)
+
+    operator fun compareTo(that: Amount) = this.pence.compareTo(that.pence)
+
+    override fun toString(): String {
+        val pounds = this.pence.div(100)
+        val pence = "%02d".format(this.pence.absoluteValue.rem(100))
+        return "£$pounds.$pence"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Amount
+
+        if (pence != other.pence) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return pence.hashCode()
+    }
+
+
+    companion object {
+
+        val ONE = Amount(100)
+        fun ofPounds(pounds: Int) = ofPounds(pounds.toLong())
+        fun ofPounds(pounds: Long) = Amount(pounds * 100)
+        fun ofPounds(pounds: Long, pence: Long): Amount {
+            require(pence < 100L) { "Max is 99 pence, but got: $pence" }
+            return Amount((pounds * 100) + pence)
+        }
+    }
+}

--- a/src/main/kotlin/funds_distribution.kt
+++ b/src/main/kotlin/funds_distribution.kt
@@ -4,6 +4,7 @@ import lmirabal.finance.Amount
 import lmirabal.model.Account
 import lmirabal.model.AccountAddress
 import lmirabal.model.Pot
+import lmirabal.model.PotName
 
 fun distributeFunds(bank: Bank, manifest: DistributionManifest) {
     val currentAccount: Account = bank.getAccountBy(manifest.mainAccount)
@@ -28,10 +29,8 @@ fun distributeFunds(bank: Bank, manifest: DistributionManifest) {
     bank.deposit(from = currentAccount, to = remainderPot, amount = remainderBalance)
 }
 
-operator fun List<Pot>.get(potName: PotName): Pot = first { it.name == potName.value }
+operator fun List<Pot>.get(potName: PotName): Pot = first { it.name == potName }
 
-@JvmInline
-value class PotName(val value: String)
 data class Deposit(val to: PotName, val amount: Amount)
 data class Remainder(val to: PotName, val atLeast: Amount)
 data class DistributionManifest(

--- a/src/main/kotlin/funds_distribution.kt
+++ b/src/main/kotlin/funds_distribution.kt
@@ -1,0 +1,50 @@
+package lmirabal
+
+import lmirabal.finance.Amount
+import lmirabal.model.Account
+import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
+
+fun distributeFunds(bank: Bank, manifest: DistributionManifest) {
+    val currentAccount: Account = bank.getAccountBy(manifest.mainAccount)
+    println(currentAccount)
+    val pots = bank.getPotsFor(currentAccount)
+
+    val sourcePot = pots[manifest.source]
+    if (sourcePot.balance < manifest.minimumSourceFunds)
+        throw IllegalArgumentException(
+            "Not enough funds: required=${manifest.minimumSourceFunds} available=${sourcePot.balance}"
+        )
+    bank.withdraw(from = sourcePot, to = currentAccount, sourcePot.balance)
+
+    for (deposit in manifest.deposits) {
+        val targetPot = pots[deposit.to]
+        bank.deposit(from = currentAccount, to = targetPot, amount = deposit.amount)
+    }
+
+    val remainderBalance = manifest.remainderAmount(sourcePot.balance)
+
+    val remainderPot = pots[manifest.remainder.to]
+    bank.deposit(from = currentAccount, to = remainderPot, amount = remainderBalance)
+}
+
+operator fun List<Pot>.get(potName: PotName): Pot = first { it.name == potName.value }
+
+@JvmInline
+value class PotName(val value: String)
+data class Deposit(val to: PotName, val amount: Amount)
+data class Remainder(val to: PotName, val atLeast: Amount)
+data class DistributionManifest(
+    val mainAccount: AccountAddress,
+    val source: PotName,
+    val deposits: List<Deposit>,
+    val keepInMainAccount: Amount,
+    val remainder: Remainder
+) {
+    private val depositAmount = deposits
+        .map { it.amount }
+        .reduce { amount1, amount2 -> amount1 + amount2 }
+
+    val minimumSourceFunds = keepInMainAccount + depositAmount + remainder.atLeast
+    fun remainderAmount(sourceBalance: Amount): Amount = sourceBalance - keepInMainAccount - depositAmount
+}

--- a/src/main/kotlin/infrastructure/monzo.kt
+++ b/src/main/kotlin/infrastructure/monzo.kt
@@ -1,0 +1,117 @@
+package lmirabal.infrastructure
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import lmirabal.finance.Amount
+import lmirabal.model.Account
+import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
+import org.http4k.client.JavaHttpClient
+import org.http4k.core.*
+import org.http4k.core.body.form
+import org.http4k.filter.ClientFilters
+import org.http4k.filter.DebuggingFilters
+import org.http4k.format.KotlinxSerialization.auto
+import org.http4k.lens.Header
+import java.util.*
+
+class MonzoApi(accessToken: String) {
+    private val client: HttpHandler = ClientFilters.SetBaseUriFrom(Uri.of("https://api.monzo.com"))
+        .then(ClientFilters.BearerAuth(accessToken))
+        .then(DebuggingFilters.PrintRequestAndResponse())
+        .then(JavaHttpClient())
+
+    fun getAccountBy(address: AccountAddress): Account {
+        fun getAccounts(): List<AccountResponse> {
+            val accountsRequest = Request(Method.GET, "/accounts")
+                .query("account_type", "uk_retail")
+            return accountsLens(client(accountsRequest))
+                .filter { !it.closed }
+        }
+
+        fun getBalance(accountId: String): Amount {
+            val balanceRequest = Request(Method.GET, "/balance")
+                .query("account_id", accountId)
+            return balanceLens(client(balanceRequest))
+        }
+
+        return getAccounts()
+            .first { account -> AccountAddress(account.sort_code, account.account_number) == address }
+            .let { it.asAccountWithBalance(getBalance(it.id)) }
+    }
+
+    fun getPotsFor(account: Account): List<Pot> {
+        val potsRequest = Request(Method.GET, "/pots").query("current_account_id", account.id)
+        return potsLens(client(potsRequest))
+            .filter { !it.deleted }
+            .map { it.asPot() }
+    }
+
+    fun deposit(from: Account, to: Pot, amount: Amount): Pot {
+        val depositRequest = Request(Method.PUT, "/pots/${to.id}/deposit")
+            .with(Header.CONTENT_TYPE of ContentType.APPLICATION_FORM_URLENCODED)
+            .form("source_account_id", from.id)
+            .form("amount", amount.pence.toString())
+            .form("dedupe_id", UUID.randomUUID().toString())
+        return potLens(client(depositRequest))
+    }
+
+    fun withdraw(from: Pot, to: Account, amount: Amount): Pot {
+        val withdrawRequest = Request(Method.PUT, "/pots/${from.id}/withdraw")
+            .with(Header.CONTENT_TYPE of ContentType.APPLICATION_FORM_URLENCODED)
+            .form("destination_account_id", to.id)
+            .form("amount", amount.pence.toString())
+            .form("dedupe_id", UUID.randomUUID().toString())
+        return potLens(client(withdrawRequest))
+    }
+}
+
+private val accountsLens = Body.auto<Accounts>()
+    .map { response -> response.accounts }
+    .toLens()
+
+private val balanceLens = Body.auto<Balance>()
+    .map { response -> response.balance }
+    .map { pence -> Amount(pence) }
+    .toLens()
+
+private val potsLens = Body.auto<Pots>()
+    .map { response -> response.pots }
+    .toLens()
+
+private val potLens = Body.auto<PotResponse>().map(PotResponse::asPot).toLens()
+
+private fun AccountResponse.asAccountWithBalance(balance: Amount) =
+    Account(id, AccountAddress(sort_code, account_number), balance)
+
+private fun PotResponse.asPot() = Pot(id, name, Amount(pence = balance))
+
+@Serializable
+private class Accounts(val accounts: List<AccountResponse>)
+
+@Serializable
+private class Balance(val balance: Long)
+
+@Suppress("unused")
+@Serializable
+private class AccountResponse(
+    val id: String,
+    val closed: Boolean,
+    val created: Instant,
+    val description: String,
+    val account_number: String,
+    val sort_code: String
+)
+
+@Serializable
+private class Pots(val pots: List<PotResponse>)
+
+@Suppress("unused")
+@Serializable
+private class PotResponse(
+    val id: String,
+    val name: String,
+    val balance: Long,
+    val updated: Instant,
+    val deleted: Boolean
+)

--- a/src/main/kotlin/infrastructure/monzo.kt
+++ b/src/main/kotlin/infrastructure/monzo.kt
@@ -7,6 +7,7 @@ import lmirabal.finance.Amount
 import lmirabal.model.Account
 import lmirabal.model.AccountAddress
 import lmirabal.model.Pot
+import lmirabal.model.PotName
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.*
 import org.http4k.core.body.form
@@ -85,7 +86,7 @@ private val potLens = Body.auto<PotResponse>().map(PotResponse::asPot).toLens()
 private fun AccountResponse.asAccountWithBalance(balance: Amount) =
     Account(id, AccountAddress(sort_code, account_number), balance)
 
-private fun PotResponse.asPot() = Pot(id, name, Amount(pence = balance))
+private fun PotResponse.asPot() = Pot(id, PotName(name), Amount(pence = balance))
 
 @Serializable
 private class Accounts(val accounts: List<AccountResponse>)

--- a/src/main/kotlin/infrastructure/monzo.kt
+++ b/src/main/kotlin/infrastructure/monzo.kt
@@ -86,7 +86,7 @@ private val potLens = Body.auto<PotResponse>().map(PotResponse::asPot).toLens()
 private fun AccountResponse.asAccountWithBalance(balance: Amount) =
     Account(id, AccountAddress(sort_code, account_number), balance)
 
-private fun PotResponse.asPot() = Pot(id, PotName(name), Amount(pence = balance))
+private fun PotResponse.asPot() = Pot(id, PotName(name.trim()), Amount(pence = balance))
 
 @Serializable
 private class Accounts(val accounts: List<AccountResponse>)

--- a/src/main/kotlin/model/model.kt
+++ b/src/main/kotlin/model/model.kt
@@ -1,0 +1,7 @@
+package lmirabal.model
+
+import lmirabal.finance.Amount
+
+data class AccountAddress(val sortCode: String, val number: String)
+data class Account(val id: String, val address: AccountAddress, val balance: Amount)
+data class Pot(val id: String, val name: String, val balance: Amount)

--- a/src/main/kotlin/model/model.kt
+++ b/src/main/kotlin/model/model.kt
@@ -4,4 +4,8 @@ import lmirabal.finance.Amount
 
 data class AccountAddress(val sortCode: String, val number: String)
 data class Account(val id: String, val address: AccountAddress, val balance: Amount)
-data class Pot(val id: String, val name: String, val balance: Amount)
+@JvmInline
+value class PotName(private val value: String) {
+    override fun toString() = value
+}
+data class Pot(val id: String, val name: PotName, val balance: Amount)

--- a/src/test/kotlin/FundsDistributionTest.kt
+++ b/src/test/kotlin/FundsDistributionTest.kt
@@ -1,7 +1,10 @@
 package lmirabal
 
+import lmirabal.finance.Amount
 import lmirabal.finance.pounds
+import lmirabal.model.Account
 import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
 import lmirabal.model.PotName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -11,18 +14,15 @@ class FundsDistributionTest {
 
     private val bank = StubBank()
     private val accountAddress = AccountAddress("123456", "123456789")
+    private val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
 
     @Test
     fun `distribute funds`() {
-        val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
-        val source = PotName("source")
-        val destination1 = PotName("destination 1")
-        val destination2 = PotName("destination 2")
-        val remainder = PotName("remainder")
-        bank.createPot(CreatePotRequest(account, source, 300.pounds))
-        bank.createPot(CreatePotRequest(account, destination1, 0.pounds))
-        bank.createPot(CreatePotRequest(account, destination2, 0.pounds))
-        bank.createPot(CreatePotRequest(account, remainder, 0.pounds))
+        val source = bank.createPot("source", 300)
+        val destination1 = bank.createPot("destination 1", 0)
+        val destination2 = bank.createPot("destination 2", 0)
+        val remainder = bank.createPot("remainder", 0)
+
         val manifest = DistributionManifest(
             mainAccount = accountAddress,
             source = source,
@@ -33,26 +33,22 @@ class FundsDistributionTest {
             keepInMainAccount = 30.pounds,
             remainder = Remainder(to = remainder, atLeast = 10.pounds)
         )
-
         distributeFunds(bank, manifest)
 
-        val pots = bank.getPotsFor(account)
-        assertEquals(0.pounds, pots[source].balance)
-        assertEquals(30.pounds, bank.getAccountBy(accountAddress).balance)
-        assertEquals(50.pounds, pots[destination1].balance)
-        assertEquals(70.pounds, pots[destination2].balance)
-        assertEquals(150.pounds, pots[remainder].balance)
+        bank.asserting()
+            .potBalance(source, 0)
+            .accountBalance(30)
+            .potBalance(destination1, 50)
+            .potBalance(destination2, 70)
+            .potBalance(remainder, 150)
     }
 
     @Test
     fun `distribute just enough funds`() {
-        val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
-        val source = PotName("source")
-        val destination = PotName("destination")
-        val remainder = PotName("remainder")
-        bank.createPot(CreatePotRequest(account, source, 90.pounds))
-        bank.createPot(CreatePotRequest(account, destination, 0.pounds))
-        bank.createPot(CreatePotRequest(account, remainder, 0.pounds))
+        val source = bank.createPot("source", 90)
+        val destination = bank.createPot("destination", 0)
+        val remainder = bank.createPot("remainder", 0)
+
         val manifest = DistributionManifest(
             mainAccount = accountAddress,
             source = source,
@@ -60,25 +56,21 @@ class FundsDistributionTest {
             keepInMainAccount = 30.pounds,
             remainder = Remainder(to = remainder, atLeast = 10.pounds)
         )
-
         distributeFunds(bank, manifest)
 
-        val pots = bank.getPotsFor(account)
-        assertEquals(0.pounds, pots[source].balance)
-        assertEquals(30.pounds, bank.getAccountBy(accountAddress).balance)
-        assertEquals(50.pounds, pots[destination].balance)
-        assertEquals(10.pounds, pots[remainder].balance)
+        bank.asserting()
+            .potBalance(source, 0)
+            .accountBalance(30)
+            .potBalance(destination, 50)
+            .potBalance(remainder, 10)
     }
 
     @Test
-    fun `not enough funds to distribute`() {
-        val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
-        val source = PotName("source")
-        val destination = PotName("destination")
-        val remainder = PotName("remainder")
-        bank.createPot(CreatePotRequest(account, source, 100.pounds))
-        bank.createPot(CreatePotRequest(account, destination, 0.pounds))
-        bank.createPot(CreatePotRequest(account, remainder, 0.pounds))
+    fun `does not distribute when not enough funds`() {
+        val source = bank.createPot("source", 100)
+        val destination = bank.createPot("destination", 0)
+        val remainder = bank.createPot("remainder", 0)
+
         val manifest = DistributionManifest(
             mainAccount = accountAddress,
             source = source,
@@ -86,10 +78,30 @@ class FundsDistributionTest {
             keepInMainAccount = 30.pounds,
             remainder = Remainder(to = remainder, atLeast = 10.pounds)
         )
-
         val exception = assertThrows<IllegalArgumentException> {
             distributeFunds(bank, manifest)
         }
+
         assertEquals("Not enough funds: required=£110.00 available=£100.00", exception.message)
+    }
+
+    private fun StubBank.createPot(name: String, initialBalance: Int) =
+        PotName(name)
+            .also { potName ->
+                createPot(CreatePotRequest(account, potName, Amount.ofPounds(initialBalance)))
+            }
+
+    private fun StubBank.asserting() = Asserter(getAccountBy(accountAddress), getPotsFor(account))
+
+    private class Asserter(private val account: Account, private val pots: List<Pot>) {
+        fun accountBalance(expectedBalance: Int): Asserter {
+            assertEquals(Amount.ofPounds(expectedBalance), account.balance)
+            return this
+        }
+
+        fun potBalance(potName: PotName, expectedBalance: Int): Asserter {
+            assertEquals(Amount.ofPounds(expectedBalance), pots[potName].balance)
+            return this
+        }
     }
 }

--- a/src/test/kotlin/FundsDistributionTest.kt
+++ b/src/test/kotlin/FundsDistributionTest.kt
@@ -1,0 +1,94 @@
+package lmirabal
+
+import lmirabal.finance.pounds
+import lmirabal.model.AccountAddress
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class FundsDistributionTest {
+
+    private val bank = StubBank()
+    private val accountAddress = AccountAddress("123456", "123456789")
+
+    @Test
+    fun `distribute funds`() {
+        val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
+        val source = PotName("source")
+        val destination1 = PotName("destination 1")
+        val destination2 = PotName("destination 2")
+        val remainder = PotName("remainder")
+        bank.createPot(CreatePotRequest(account, source, 300.pounds))
+        bank.createPot(CreatePotRequest(account, destination1, 0.pounds))
+        bank.createPot(CreatePotRequest(account, destination2, 0.pounds))
+        bank.createPot(CreatePotRequest(account, remainder, 0.pounds))
+        val manifest = DistributionManifest(
+            mainAccount = accountAddress,
+            source = source,
+            deposits = listOf(
+                Deposit(to = destination1, amount = 50.pounds),
+                Deposit(to = destination2, amount = 70.pounds)
+            ),
+            keepInMainAccount = 30.pounds,
+            remainder = Remainder(to = remainder, atLeast = 10.pounds)
+        )
+
+        distributeFunds(bank, manifest)
+
+        val pots = bank.getPotsFor(account)
+        assertEquals(0.pounds, pots[source].balance)
+        assertEquals(30.pounds, bank.getAccountBy(accountAddress).balance)
+        assertEquals(50.pounds, pots[destination1].balance)
+        assertEquals(70.pounds, pots[destination2].balance)
+        assertEquals(150.pounds, pots[remainder].balance)
+    }
+
+    @Test
+    fun `distribute just enough funds`() {
+        val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
+        val source = PotName("source")
+        val destination = PotName("destination")
+        val remainder = PotName("remainder")
+        bank.createPot(CreatePotRequest(account, source, 90.pounds))
+        bank.createPot(CreatePotRequest(account, destination, 0.pounds))
+        bank.createPot(CreatePotRequest(account, remainder, 0.pounds))
+        val manifest = DistributionManifest(
+            mainAccount = accountAddress,
+            source = source,
+            deposits = listOf(Deposit(to = destination, amount = 50.pounds)),
+            keepInMainAccount = 30.pounds,
+            remainder = Remainder(to = remainder, atLeast = 10.pounds)
+        )
+
+        distributeFunds(bank, manifest)
+
+        val pots = bank.getPotsFor(account)
+        assertEquals(0.pounds, pots[source].balance)
+        assertEquals(30.pounds, bank.getAccountBy(accountAddress).balance)
+        assertEquals(50.pounds, pots[destination].balance)
+        assertEquals(10.pounds, pots[remainder].balance)
+    }
+
+    @Test
+    fun `not enough funds to distribute`() {
+        val account = bank.createAccount(CreateAccountRequest(accountAddress, 0.pounds))
+        val source = PotName("source")
+        val destination = PotName("destination")
+        val remainder = PotName("remainder")
+        bank.createPot(CreatePotRequest(account, source, 100.pounds))
+        bank.createPot(CreatePotRequest(account, destination, 0.pounds))
+        bank.createPot(CreatePotRequest(account, remainder, 0.pounds))
+        val manifest = DistributionManifest(
+            mainAccount = accountAddress,
+            source = source,
+            deposits = listOf(Deposit(to = destination, amount = 70.pounds)),
+            keepInMainAccount = 30.pounds,
+            remainder = Remainder(to = remainder, atLeast = 10.pounds)
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            distributeFunds(bank, manifest)
+        }
+        assertEquals("Not enough funds: required=£110.00 available=£100.00", exception.message)
+    }
+}

--- a/src/test/kotlin/FundsDistributionTest.kt
+++ b/src/test/kotlin/FundsDistributionTest.kt
@@ -2,6 +2,7 @@ package lmirabal
 
 import lmirabal.finance.pounds
 import lmirabal.model.AccountAddress
+import lmirabal.model.PotName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals

--- a/src/test/kotlin/StubBankTest.kt
+++ b/src/test/kotlin/StubBankTest.kt
@@ -106,6 +106,6 @@ class StubBankTest {
     }
 
     private fun StubBank.createPot(name: String, balance: Amount): Pot {
-        return createPot(CreatePotRequest(sampleAccount, name, balance))
+        return createPot(CreatePotRequest(sampleAccount, PotName(name), balance))
     }
 }

--- a/src/test/kotlin/StubBankTest.kt
+++ b/src/test/kotlin/StubBankTest.kt
@@ -5,6 +5,7 @@ import lmirabal.finance.pounds
 import lmirabal.model.Account
 import lmirabal.model.AccountAddress
 import lmirabal.model.Pot
+import lmirabal.model.PotName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
@@ -42,7 +43,7 @@ class StubBankTest {
 
         val pot = bank.createPot("pot", 100.pounds)
 
-        assertEquals(Pot("id", "pot", 100.pounds), pot)
+        assertEquals(Pot("id", PotName("pot"), 100.pounds), pot)
     }
 
     @Test

--- a/src/test/kotlin/StubBankTest.kt
+++ b/src/test/kotlin/StubBankTest.kt
@@ -1,0 +1,111 @@
+package lmirabal
+
+import lmirabal.finance.Amount
+import lmirabal.finance.pounds
+import lmirabal.model.Account
+import lmirabal.model.AccountAddress
+import lmirabal.model.Pot
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class StubBankTest {
+    @Test
+    fun `creates an account`() {
+        val account = bank.createAccount(
+            CreateAccountRequest(
+                AccountAddress(sortCode = "123456", number = "123456789"),
+                100.pounds
+            )
+        )
+
+        assertEquals(
+            Account(
+                "id",
+                AccountAddress(sortCode = "123456", number = "123456789"),
+                100.pounds
+            ),
+            account
+        )
+    }
+
+    @Test
+    fun `gets an account`() {
+        val account = bank.createSampleAccount()
+
+        assertEquals(account, bank.getSampleAccount())
+    }
+
+    @Test
+    fun `creates a pot for an account`() {
+        bank.createSampleAccount()
+
+        val pot = bank.createPot("pot", 100.pounds)
+
+        assertEquals(Pot("id", "pot", 100.pounds), pot)
+    }
+
+    @Test
+    fun `gets pots for an account`() {
+        val account = bank.createSampleAccount()
+        val pot1 = bank.createPot("pot1", 100.pounds)
+        val pot2 = bank.createPot("pot2", 200.pounds)
+
+        assertEquals(listOf(pot1, pot2), bank.getPotsFor(account))
+    }
+
+    @Test
+    fun `moves funds between pots`() {
+        val account = bank.createSampleAccount()
+        val source = bank.createPot("source", 100.pounds)
+        val destination = bank.createPot("destination", 200.pounds)
+
+        val updatedSource = bank.withdraw(source, account, 70.pounds)
+        assertEquals(30.pounds, updatedSource.balance)
+        assertEquals(70.pounds, bank.getSampleAccountBalance())
+
+        val updatedDestination = bank.deposit(account, destination, 70.pounds)
+        assertEquals(270.pounds, updatedDestination.balance)
+        assertEquals(0.pounds, bank.getSampleAccountBalance())
+    }
+
+    @Test
+    fun `fails to withdraw from account more than available funds`() {
+        val account = bank.createSampleAccount()
+        val pot = bank.createPot("pot", 0.pounds)
+
+        assertThrows<IllegalArgumentException> {
+            bank.deposit(from = account, to = pot, 100.pounds)
+        }
+    }
+
+    @Test
+    fun `fails to withdraw from pot more than available funds`() {
+        val account = bank.createSampleAccount()
+        val pot = bank.createPot("pot", 0.pounds)
+
+        assertThrows<IllegalArgumentException> {
+            bank.withdraw(from = pot, to = account, 100.pounds)
+        }
+    }
+
+    private fun StubBank.getSampleAccountBalance() = getSampleAccount().balance
+
+    private val bank = StubBank { "id" }
+    private val sampleAddress = AccountAddress(sortCode = "123456", number = "123456789")
+    private val sampleBalance = Amount.ZERO
+    private val sampleAccountRequest = CreateAccountRequest(sampleAddress, sampleBalance)
+    private val sampleAccount = Account("id", sampleAddress, sampleBalance)
+
+    private fun StubBank.createSampleAccount(): Account {
+        return createAccount(sampleAccountRequest)
+    }
+
+    private fun StubBank.getSampleAccount(): Account {
+        return getAccountBy(sampleAddress)
+    }
+
+    private fun StubBank.createPot(name: String, balance: Amount): Pot {
+        return createPot(CreatePotRequest(sampleAccount, name, balance))
+    }
+}

--- a/src/test/kotlin/finance/AmountTest.kt
+++ b/src/test/kotlin/finance/AmountTest.kt
@@ -1,0 +1,46 @@
+package lmirabal.finance
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class AmountTest {
+
+    @Test
+    fun `can be built from Pounds`() {
+        assertEquals(Amount(100), 1.pound)
+        assertEquals(Amount(1_000), 10.pounds)
+        assertEquals(Amount(1_000), Amount.ofPounds(10))
+        assertEquals(Amount(1_000), Amount.ofPounds(10L))
+    }
+
+    @Test
+    fun `can be built from Pounds and pence`() {
+        assertEquals(Amount(1_010), Amount.ofPounds(10, 10))
+    }
+
+    @ParameterizedTest
+    @CsvSource("200,50,150", "100,0,100", "0,0,0")
+    fun `can be added up`(expected: Long, pence1: Long, pence2: Long) {
+        assertEquals(Amount(expected), Amount(pence1) + Amount(pence2))
+    }
+
+    @ParameterizedTest
+    @CsvSource("30,150,120", "100,100,0", "0,0,0", "-20,120,140")
+    fun `can be subtracted`(expected: Long, pence1: Long, pence2: Long) {
+        assertEquals(Amount(expected), Amount(pence1) - Amount(pence2))
+    }
+
+    @ParameterizedTest
+    @CsvSource("-100,100", "100,-100", "0,0")
+    fun `can be negated`(expected: Long, pence: Long) {
+        assertEquals(Amount(expected), -Amount(pence))
+    }
+
+    @ParameterizedTest
+    @CsvSource("£1.11,111", "£1.00,100", "£10.00,1000", "£10.10,1010,", "£-12.34,-1234", "£1000.00,100_000")
+    fun `toString is formatted`(expected: String, pence: Long) {
+        assertEquals(expected, Amount(pence).toString())
+    }
+}


### PR DESCRIPTION
### Initial API discovery

Used monzo api to move money around pots, using a manually obtained
access token (via https://developers.monzo.com/).

Picked http4k as a nice facade for the http client, to make the api
consumption much simpler. I wasn't sure what to use for serialisation,
but given that we're using kotlin, it made sense to explore kotlinx.

Introduce a type to handle amounts, and assumed it's always sterling
pounds, as this project only intends to get details about a Monzo UK
account.

### Implement stub version

It'd be too dangerous to test moving money between pots with an actual
account, so extracted an interface from the monzo api so that we can
have a stub implementation that we can use for testing purposes.

There's no guarantee the stub behaves like the real thing, but we can't
really run the same tests against a real account to make sure is the
case. However, the idea is to use the api in very simple way, so this
stub should be enough.

### Command to distribute funds into pots

Using the bank abstraction, this command takes funds from a source pot
and distribute them into the deposit pots.

As the source pot could have a different amount every month, define a
remainder pot that takes the funds that were not distributed, so that
the main account is unaffected - all the funds that get withdrawn from
the source pot get distributed.

The remainder can be used for savings, so defined a minimum amount that
should make it into the pod. This way, you could ensure you're saving
enough, or the command fails. In the case your income is greater than
usual, then you just end up with more funds in the pot, which should
actually be a good thing, if the pot was about savings.

### Move pot name type to model

Pot name has become an important type, so it's better to use it beyond
fund distribution and across the bank model.

### Refactor fund distribution tests

Tests were getting quite long, so extract a few extension functions to
hide some of the implementation details from the test cases. This should
make them a lot easier to follow.

### Validate pots exist before attempting to distribute funds

Running the command against my actual account failed because some pots
had spaces at the end of their name, so they couldn't be found.

Therefore, we need to validate they exist before starting to make
movements,

However, some movements were made before the pot with the name issue was
found, so part of the distribution happened, and the command couldn't be
re-run without manually moving the funds back to the source.

Validating that all the pots included in the manifest exist will prevent
this issue from happening.

### Trim pot names when parsing monzo response

Running the distribute funds command against my actual account failed
because some pots had spaces at the end of their name, so they couldn't
be found.

This issue was considered a bug on monzo's part, as having leading or
trailing spaces shouldn't be allowed. For that reason, the change is
made in the monzo implementation rather than in the command. A
consequence of that is that we can't really test it, as we can't run
tests against an actual monzo account. This was considered acceptable
given the simplicity of the problem.

### Initial readme describing the project
