### PR TITLE
Gradle improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") version "1.8.0"
     kotlin("plugin.serialization") version "1.8.0"
     application
+    alias(libs.plugins.testlogger)
 }
 
 group = "lmirabal"
@@ -20,6 +21,9 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
+    systemProperties["junit.jupiter.execution.parallel.mode.default"] = "same_thread"
+    systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
 }
 
 kotlin {
@@ -28,4 +32,8 @@ kotlin {
 
 application {
     mainClass.set("lmirabal.MainKt")
+}
+
+testlogger {
+    theme = com.adarshr.gradle.testlogger.theme.ThemeType.STANDARD_PARALLEL
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 kotlin.code.style=official
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,3 +6,6 @@ http4k-core = { module = "org.http4k:http4k-core", version.ref = "http4k" }
 http4k-serialisation-kotlinx = { module = "org.http4k:http4k-format-kotlinx-serialization", version.ref = "http4k" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.0" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.8.1" }
+
+[plugins]
+testlogger = { id = "com.adarshr.test-logger", version = "3.2.0" }


### PR DESCRIPTION
### Run tests in parallel and use nicer format in the build test output

### Improve gradle performance

Using the build cache and building in parallel. This doesn't make a
massive difference just yet, but it should help as the build becomes
more complex.

